### PR TITLE
Install requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 from distutils.core import setup
 
+with open("requirements.txt") as f:
+    REQUIREMENTS = f.read().splitlines()
+
 setup(
     name="moonfire_tokenomics",
     version="1.0",
+    install_requires=REQUIREMENTS,
     extras_require={
         "testing": ["pytest"],
     },


### PR DESCRIPTION
We include all dependencies from `requirements.txt` in `setup.py` so that they get installed when you install the package with pip 